### PR TITLE
Fix case of unweighted graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## [0.1.1] - 2021-03-02
+
+* Fixed issue with unweighted graph. In this case, we set all edge weights to 1. 
+
+
+## [0.1.0] - 2020-11-11
+
+* Version published on CRAN: https://cran.r-project.org/web/packages/leidenAlg/index.html
+* Tagged version on github released on 2 Jan 2021: https://github.com/kharchenkolab/leidenAlg/releases/tag/0.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,7 @@
 Package: leidenAlg
 Type: Package
 Title: Implements the Leiden Algorithm via an R Interface
-Version: 0.1.0
-Date: 2020-11-06
+Version: 0.1.1
 Authors@R: c(person("Peter", "Kharchenko", email = "Peter_Kharchenko@hms.harvard.edu", role = c("aut")), person("Viktor", "Petukhov", email = "viktor.s.petukhov@ya.ru", role = c("aut")), person("V.A.", "Traag", email = "v.a.traag@cwts.leidenuniv.nl", role = c("ctb")), person("Gábor", "Csárdi", email = "sardi.gabor@gmail.com", role = c("ctb")), person("Tamás", "Nepusz", email = "ntamas@gmail.com", role = c("ctb")), person("Minh Van", "Nguyen", email = "nguyenminh2@gmail.com", role = c("ctb")), person("Evan", "Biederstedt", email = "evan.biederstedt@gmail.com", role=c("cre", "aut")))
 Description: An R interface to the Leiden algorithm, an iterative community detection algorithm on networks. The algorithm is designed to converge to a partition in which all subsets of all communities are locally optimally assigned, yielding communities guaranteed to be connected. The implementation proves to be fast, scales well, and can be run on graphs of millions of nodes (as long as they can fit in memory). The original implementation was constructed as a python interface "leidenalg" found here: <https://github.com/vtraag/leidenalg>. The algorithm was originally described in Traag, V.A., Waltman, L. & van Eck, N.J. "From Louvain to Leiden: guaranteeing well-connected communities". Sci Rep 9, 5233 (2019) <doi:10.1038/s41598-019-41695-z>.
 License: GPL-3 

--- a/R/communities.R
+++ b/R/communities.R
@@ -34,7 +34,7 @@ leiden.community <- function(graph, resolution=1.0, n.iterations=2) {
   ## add check for unweighted graph, i.e. graph$weight is NULL
   if (!igraph::is_weighted(graph)){
     ## simply set the vector of edge weights to 1
-    igraph::E(graph)$weight = 1
+    igraph::E(graph)$weight <- 1
   }
 
   x <- find_partition(graph, igraph::E(graph)$weight, resolution, n.iterations)

--- a/R/communities.R
+++ b/R/communities.R
@@ -32,9 +32,9 @@ NULL
 leiden.community <- function(graph, resolution=1.0, n.iterations=2) {
 
   ## add check for unweighted graph, i.e. graph$weight is NULL
-  if (igraph::is_weighted(graph)){
+  if (!igraph::is_weighted(graph)){
     ## simply set the vector of edge weights to 1
-    igraph::E(gr)$weight = 1
+    igraph::E(graph)$weight = 1
   }
 
   x <- find_partition(graph, igraph::E(graph)$weight, resolution, n.iterations)

--- a/R/communities.R
+++ b/R/communities.R
@@ -31,6 +31,12 @@ NULL
 #' @export 
 leiden.community <- function(graph, resolution=1.0, n.iterations=2) {
 
+  ## add check for unweighted graph, i.e. graph$weight is NULL
+  if (igraph::is_weighted(graph)){
+    ## simply set the vector of edge weights to 1
+    igraph::E(gr)$weight = 1
+  }
+
   x <- find_partition(graph, igraph::E(graph)$weight, resolution, n.iterations)
 
   # enclose in a masquerading class


### PR DESCRIPTION
Related to this issue: https://github.com/kharchenkolab/leidenAlg/issues/2

* `leiden.community()` checks if the graph is unweighed. If so, it will change all edge weights to 1, and input into `find_partition()`
* Added CHANGELOG.md as well

I believe this is the correct behavior, but I could be wrong. I don't see the value in throwing an error for an graph input whereby the weights are `NULL`. 
